### PR TITLE
The blacklist hours are now specified in UTC

### DIFF
--- a/cloud-native/pre-emptible-killer/templates/values.yaml
+++ b/cloud-native/pre-emptible-killer/templates/values.yaml
@@ -94,7 +94,7 @@ extraArgs: []
 
 # use to set extra environment variables
 extraEnv:
-  BLACKLIST_HOURS: "08:00-20:00"
+  BLACKLIST_HOURS: "15:00-03:00"  # Specified in UTC, this is 7/8 AM to 7/8 PM
 
 # use to add extra labels
 extraLabels: {}


### PR DESCRIPTION
I've verified that this works in dev-toniq-dev, at 8 AM in the morning all nodes should live longer than 12 hours:
<nil> INF Listing all preemptible nodes for cluster...
<nil> INF Cluster has 13 preemptible nodes
<nil> INF 969 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-48f97a99-38jb
<nil> INF 930 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-48f97a99-5dv8
<nil> INF 761 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-48f97a99-fnfx
<nil> INF 869 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-48f97a99-lfx2
<nil> INF 836 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-68297492-4v2r
<nil> INF 913 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-68297492-5ljr
<nil> INF 1068 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-68297492-pm94
<nil> INF 736 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-68297492-rpc4
<nil> INF 991 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-d3c7dd6a-7sgv
<nil> INF 787 minute(s) to go before kill, keeping node host=gke-internal-toniq-stage-1a9e-default-d3c7dd6a-b2jd
