### PR TITLE
Create user-agent mappings and load CRDs with Helm chart.

### DIFF
--- a/cloud-native/ambassador/main.tf
+++ b/cloud-native/ambassador/main.tf
@@ -37,14 +37,21 @@ resource "helm_release" "ambassador" {
   }
 }
 
-resource "kubernetes_manifest" "mapping" {
-  provider = kubernetes
-  for_each = var.user_agents_block
-  manifest = yamldecode(templatefile("./${path.module}/templates/user-agent-mapping.yaml",
-    {
-      USER_AGENT = each.value,
-      SUFFIX     = each.key
-  }))
+resource "helm_release" "manifests" {
+  name         = "ambassador-manifests"
+  chart        = "${path.module}/manifests"
+  version      = "1.0.0"
+  namespace    = "ingress"
+  force_update = true
+  lint         = true
+
+#  dynamic "set" {
+#    for_each = var.user_agents_block
+#    content {
+#      name  = "user_agent_mappings.${set.key}"
+#      value = set.value
+#    }
+#  }
   depends_on = [
     helm_release.ambassador
   ]

--- a/cloud-native/ambassador/manifests/.helmignore
+++ b/cloud-native/ambassador/manifests/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/cloud-native/ambassador/manifests/Chart.yaml
+++ b/cloud-native/ambassador/manifests/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: manifests
+description: Ambassador manifests workaround for kubernetes_manifest
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/cloud-native/ambassador/manifests/crds/ambassador-crds.yaml
+++ b/cloud-native/ambassador/manifests/crds/ambassador-crds.yaml
@@ -1,0 +1,1566 @@
+# GENERATED FILE: edits made by hand will not be preserved.
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: authservices.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: AuthService
+    listKind: AuthServiceList
+    plural: authservices
+    singular: authservice
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: AuthService is the Schema for the authservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AuthServiceSpec defines the desired state of AuthService
+          properties:
+            add_auth_headers:
+              additionalProperties:
+                description: BoolOrString is a type that can hold a Boolean or a string.
+                oneOf:
+                - type: string
+                - type: boolean
+              type: object
+            add_linkerd_headers:
+              type: boolean
+            allow_request_body:
+              type: boolean
+            allowed_authorization_headers:
+              items:
+                type: string
+              type: array
+            allowed_request_headers:
+              items:
+                type: string
+              type: array
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            auth_service:
+              type: string
+            failure_mode_allow:
+              type: boolean
+            include_body:
+              properties:
+                allow_partial:
+                  type: boolean
+                max_bytes:
+                  description: These aren't pointer types because they are required.
+                  type: integer
+              required:
+              - allow_partial
+              - max_bytes
+              type: object
+            path_prefix:
+              type: string
+            proto:
+              enum:
+              - http
+              - grpc
+              type: string
+            protocol_version:
+              enum:
+              - v2
+              - v3
+              type: string
+            status_on_error:
+              description: Why isn't this just an int??
+              properties:
+                code:
+                  type: integer
+              type: object
+            timeout_ms:
+              type: integer
+            tls:
+              description: BoolOrString is a type that can hold a Boolean or a string.
+              oneOf:
+              - type: string
+              - type: boolean
+          required:
+          - auth_service
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: consulresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: ConsulResolver
+    listKind: ConsulResolverList
+    plural: consulresolvers
+    singular: consulresolver
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: ConsulResolver is the Schema for the ConsulResolver API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ConsulResolver tells Ambassador to use Consul to resolve services. In addition to the AmbassadorID, it needs information about which Consul server and DC to use.
+          properties:
+            address:
+              type: string
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            datacenter:
+              type: string
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: devportals.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: DevPortal
+    listKind: DevPortalList
+    plural: devportals
+    singular: devportal
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: "DevPortal is the Schema for the DevPortals API \n DevPortal resources specify the `what` and `how` is shown in a DevPortal: \n * `what` is in a DevPortal can be controlled with   - a `selector`, that can be used for filtering `Mappings`.   - a `docs` listing of (services, url) * `how` is a pointer to some `contents` (a checkout of a Git repository   with go-templates/markdown/css). \n Multiple `DevPortal`s can exist in the cluster, and the Dev Portal server will show them at different endpoints. A `DevPortal` resource with a special name, `ambassador`, will be used for configuring the default Dev Portal (served at `/docs/` by default)."
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DevPortalSpec defines the desired state of DevPortal
+          properties:
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            content:
+              description: Content specifies where the content shown in the DevPortal come from
+              properties:
+                branch:
+                  type: string
+                dir:
+                  type: string
+                url:
+                  type: string
+              type: object
+            default:
+              description: Default must be true when this is the default DevPortal
+              type: boolean
+            docs:
+              description: Docs is a static docs definition
+              items:
+                description: 'DevPortalDocsSpec is a static documentation definition: instead of using a Selector for finding documentation for services, users can provide a static list of <service>:<URL> tuples. These services will be shown in the Dev Portal with the documentation obtained from this URL.'
+                properties:
+                  service:
+                    description: Service is the service being documented
+                    type: string
+                  timeout_ms:
+                    description: Timeout specifies the amount of time devportal will wait for the downstream service to report an openapi spec back
+                    type: integer
+                  url:
+                    description: URL is the URL used for obtaining docs
+                    type: string
+                type: object
+              type: array
+            naming_scheme:
+              description: Describes how to display "services" in the DevPortal. Default namespace.name
+              enum:
+              - namespace.name
+              - name.prefix
+              type: string
+            preserve_servers:
+              description: Configures this DevPortal to use server definitions from the openAPI doc instead of rewriting them based on the url used for the connection.
+              type: boolean
+            search:
+              description: DevPortalSearchSpec allows configuration over search functionality for the DevPortal
+              properties:
+                enabled:
+                  type: boolean
+                type:
+                  description: 'Type of search. "title-only" does a fuzzy search over openapi and page titles "all-content" will fuzzy search over all openapi and page content. "title-only" is the default. warning:  using all-content may incur a larger memory footprint'
+                  enum:
+                  - title-only
+                  - all-content
+                  type: string
+              type: object
+            selector:
+              description: Selector is used for choosing what is shown in the DevPortal
+              properties:
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: MatchLabels specifies the list of labels that must be present in Mappings for being present in this DevPortal.
+                  type: object
+                matchNamespaces:
+                  description: MatchNamespaces is a list of namespaces that will be included in this DevPortal.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: hosts.getambassador.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hostname
+    name: Hostname
+    type: string
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .status.phaseCompleted
+    name: Phase Completed
+    type: string
+  - JSONPath: .status.phasePending
+    name: Phase Pending
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: Host
+    listKind: HostList
+    plural: hosts
+    singular: host
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Host is the Schema for the hosts API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: HostSpec defines the desired state of Host
+          properties:
+            acmeProvider:
+              description: Specifies whether/who to talk ACME with to automatically manage the $tlsSecret.
+              properties:
+                authority:
+                  description: Specifies who to talk ACME with to get certs. Defaults to Let's Encrypt; if "none" (case-insensitive), do not try to do ACME for this Host.
+                  type: string
+                email:
+                  type: string
+                privateKeySecret:
+                  description: "Specifies the Kubernetes Secret to use to store the private key of the ACME account (essentially, where to store the auto-generated password for the auto-created ACME account).  You should not normally need to set this--the default value is based on a combination of the ACME authority being registered wit and the email address associated with the account. \n Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation."
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                registration:
+                  description: This is normally set automatically
+                  type: string
+              type: object
+            ambassador_id:
+              description: Common to all Ambassador objects (and optional).
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            ambassadorId:
+              description: A compatibility alias for "ambassador_id"; because Host used to be specified with protobuf, and jsonpb allowed either "ambassador_id" or "ambassadorId", and even though we didn't tell people about "ambassadorId" it's what the web policy console generated because of jsonpb.  So Hosts with 'ambassadorId' exist in the wild.
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            hostname:
+              description: Hostname by which the Ambassador can be reached.
+              type: string
+            previewUrl:
+              description: Configuration for the Preview URL feature of Service Preview. Defaults to preview URLs not enabled.
+              properties:
+                enabled:
+                  description: Is the Preview URL feature enabled?
+                  type: boolean
+                type:
+                  description: What type of Preview URL is allowed?
+                  enum:
+                  - Path
+                  type: string
+              type: object
+            requestPolicy:
+              description: Request policy definition.
+              properties:
+                insecure:
+                  properties:
+                    action:
+                      enum:
+                      - Redirect
+                      - Reject
+                      - Route
+                      type: string
+                    additionalPort:
+                      type: integer
+                  type: object
+              type: object
+            selector:
+              description: Selector by which we can find further configuration. Defaults to hostname=$hostname
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - key
+                    - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                  type: object
+              type: object
+            tls:
+              description: TLS configuration.  It is not valid to specify both `tlsContext` and `tls`.
+              properties:
+                alpn_protocols:
+                  type: string
+                ca_secret:
+                  type: string
+                cacert_chain_file:
+                  type: string
+                cert_chain_file:
+                  type: string
+                cert_required:
+                  type: boolean
+                cipher_suites:
+                  items:
+                    type: string
+                  type: array
+                ecdh_curves:
+                  items:
+                    type: string
+                  type: array
+                max_tls_version:
+                  type: string
+                min_tls_version:
+                  type: string
+                private_key_file:
+                  type: string
+                redirect_cleartext_from:
+                  type: integer
+                sni:
+                  type: string
+              type: object
+            tlsContext:
+              description: "Name of the TLSContext the Host resource is linked with. It is not valid to specify both `tlsContext` and `tls`. \n Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation."
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+              type: object
+            tlsSecret:
+              description: "Name of the Kubernetes secret into which to save generated certificates.  If ACME is enabled (see $acmeProvider), then the default is $hostname; otherwise the default is \"\".  If the value is \"\", then we do not do TLS for this Host. \n Note that this is a native-Kubernetes-style core.v1.LocalObjectReference, not an Ambassador-style `{name}.{namespace}` string.  Because we're opinionated, it does not support referencing a Secret in another namespace (because most native Kubernetes resources don't support that), but if we ever abandon that opinion and decide to support non-local references it, it would be by adding a `namespace:` field by changing it from a core.v1.LocalObjectReference to a core.v1.SecretReference, not by adopting the `{name}.{namespace}` notation."
+              properties:
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                  type: string
+              type: object
+          type: object
+        status:
+          description: HostStatus defines the observed state of Host
+          properties:
+            errorBackoff:
+              type: string
+            errorReason:
+              description: errorReason, errorTimestamp, and errorBackoff are valid when state==Error.
+              type: string
+            errorTimestamp:
+              format: date-time
+              type: string
+            phaseCompleted:
+              description: phaseCompleted and phasePending are valid when state==Pending or state==Error.
+              enum:
+              - NA
+              - DefaultsFilled
+              - ACMEUserPrivateKeyCreated
+              - ACMEUserRegistered
+              - ACMECertificateChallenge
+              type: string
+            phasePending:
+              description: phaseCompleted and phasePending are valid when state==Pending or state==Error.
+              enum:
+              - NA
+              - DefaultsFilled
+              - ACMEUserPrivateKeyCreated
+              - ACMEUserRegistered
+              - ACMECertificateChallenge
+              type: string
+            state:
+              description: The first value listed in the Enum marker becomes the "zero" value, and it would be great if "Pending" could be the default value; but it's Important that the "zero" value be able to be shown as empty/omitted from display, and we really do want `kubectl get hosts` to say "Pending" in the "STATE" column, and not leave the column empty.
+              enum:
+              - Initial
+              - Pending
+              - Ready
+              - Error
+              type: string
+            tlsCertificateSource:
+              enum:
+              - Unknown
+              - None
+              - Other
+              - ACME
+              type: string
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: kubernetesendpointresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: KubernetesEndpointResolver
+    listKind: KubernetesEndpointResolverList
+    plural: kubernetesendpointresolvers
+    singular: kubernetesendpointresolver
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: KubernetesEndpointResolver is the Schema for the kubernetesendpointresolver API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubernetesEndpointResolver tells Ambassador to use Kubernetes Endpoints resources to resolve services. It actually has no spec other than the AmbassadorID.
+          properties:
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: kubernetesserviceresolvers.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: KubernetesServiceResolver
+    listKind: KubernetesServiceResolverList
+    plural: kubernetesserviceresolvers
+    singular: kubernetesserviceresolver
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: KubernetesServiceResolver is the Schema for the kubernetesserviceresolver API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubernetesServiceResolver tells Ambassador to use Kubernetes Service resources to resolve services. It actually has no spec other than the AmbassadorID.
+          properties:
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: logservices.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: LogService
+    listKind: LogServiceList
+    plural: logservices
+    singular: logservice
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: LogService is the Schema for the logservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: LogServiceSpec defines the desired state of LogService
+          properties:
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            driver:
+              enum:
+              - tcp
+              - http
+              type: string
+            driver_config:
+              properties:
+                additional_log_headers:
+                  items:
+                    properties:
+                      during_request:
+                        type: boolean
+                      during_response:
+                        type: boolean
+                      during_trailer:
+                        type: boolean
+                      header_name:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+            flush_interval_byte_size:
+              type: integer
+            flush_interval_time:
+              type: integer
+            grpc:
+              type: boolean
+            service:
+              type: string
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: mappings.getambassador.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.host
+    name: Source Host
+    type: string
+  - JSONPath: .spec.prefix
+    name: Source Prefix
+    type: string
+  - JSONPath: .spec.service
+    name: Dest Service
+    type: string
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: Mapping
+    listKind: MappingList
+    plural: mappings
+    singular: mapping
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Mapping is the Schema for the mappings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MappingSpec defines the desired state of Mapping
+          properties:
+            add_linkerd_headers:
+              type: boolean
+            add_request_headers:
+              additionalProperties:
+                oneOf:
+                - type: string
+                - type: boolean
+                - type: object
+              type: object
+            add_response_headers:
+              additionalProperties:
+                oneOf:
+                - type: string
+                - type: boolean
+                - type: object
+              type: object
+            allow_upgrade:
+              description: "A case-insensitive list of the non-HTTP protocols to allow \"upgrading\" to from HTTP via the \"Connection: upgrade\" mechanism[1].  After the upgrade, Ambassador does not interpret the traffic, and behaves similarly to how it does for TCPMappings. \n [1]: https://tools.ietf.org/html/rfc7230#section-6.7 \n For example, if your upstream service supports WebSockets, you would write \n    allow_upgrade:    - websocket \n Or if your upstream service supports upgrading from HTTP to SPDY (as the Kubernetes apiserver does for `kubectl exec` functionality), you would write \n    allow_upgrade:    - spdy/3.1"
+              items:
+                type: string
+              type: array
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            auth_context_extensions:
+              additionalProperties:
+                type: string
+              type: object
+            auto_host_rewrite:
+              type: boolean
+            bypass_auth:
+              type: boolean
+            bypass_error_response_overrides:
+              description: If true, bypasses any `error_response_overrides` set on the Ambassador module.
+              type: boolean
+            case_sensitive:
+              type: boolean
+            circuit_breakers:
+              items:
+                properties:
+                  max_connections:
+                    type: integer
+                  max_pending_requests:
+                    type: integer
+                  max_requests:
+                    type: integer
+                  max_retries:
+                    type: integer
+                  priority:
+                    enum:
+                    - default
+                    - high
+                    type: string
+                type: object
+              type: array
+            cluster_idle_timeout_ms:
+              type: integer
+            cluster_max_connection_lifetime_ms:
+              type: integer
+            cluster_tag:
+              type: string
+            connect_timeout_ms:
+              type: integer
+            cors:
+              properties:
+                credentials:
+                  type: boolean
+                exposed_headers:
+                  description: StringOrStringList is just what it says on the tin, but note that it will always marshal as a list of strings right now.
+                  items:
+                    type: string
+                  oneOf:
+                  - type: string
+                  - type: array
+                headers:
+                  description: StringOrStringList is just what it says on the tin, but note that it will always marshal as a list of strings right now.
+                  items:
+                    type: string
+                  oneOf:
+                  - type: string
+                  - type: array
+                max_age:
+                  type: string
+                methods:
+                  description: StringOrStringList is just what it says on the tin, but note that it will always marshal as a list of strings right now.
+                  items:
+                    type: string
+                  oneOf:
+                  - type: string
+                  - type: array
+                origins:
+                  description: StringLiteralOrStringList is mostly like StringOrStringList, but instead of always forcing a list of strings, it will marshal a string literal as a string.
+                  oneOf:
+                  - type: string
+                  - type: array
+              type: object
+            dns_type:
+              type: string
+            docs:
+              description: DocsInfo provides some extra information about the docs for the Mapping (used by the Dev Portal)
+              properties:
+                display_name:
+                  type: string
+                ignored:
+                  type: boolean
+                path:
+                  type: string
+                timeout_ms:
+                  type: integer
+                url:
+                  type: string
+              type: object
+            enable_ipv4:
+              type: boolean
+            enable_ipv6:
+              type: boolean
+            envoy_override:
+              description: UntypedDict is relatively opaque as a Go type, but it preserves its contents in a roundtrippable way.
+              type: object
+            error_response_overrides:
+              description: Error response overrides for this Mapping. Replaces all of the `error_response_overrides` set on the Ambassador module, if any.
+              items:
+                description: A response rewrite for an HTTP error response
+                properties:
+                  body:
+                    description: The new response body
+                    properties:
+                      content_type:
+                        description: The content type to set on the error response body when using text_format or text_format_source. Defaults to 'text/plain'.
+                        type: string
+                      json_format:
+                        additionalProperties:
+                          type: string
+                        description: 'A JSON response with content-type: application/json. The values can contain format text like in text_format.'
+                        type: object
+                      text_format:
+                        description: A format string representing a text response body. Content-Type can be set using the `content_type` field below.
+                        type: string
+                      text_format_source:
+                        description: A format string sourced from a file on the Ambassador container. Useful for larger response bodies that should not be placed inline in configuration.
+                        properties:
+                          filename:
+                            description: The name of a file on the Ambassador pod that contains a format text string.
+                            type: string
+                        type: object
+                    type: object
+                  on_status_code:
+                    description: The status code to match on -- not a pointer because it's required.
+                    maximum: 599
+                    minimum: 400
+                    type: integer
+                required:
+                - body
+                - on_status_code
+                type: object
+              minItems: 1
+              type: array
+            grpc:
+              type: boolean
+            headers:
+              additionalProperties:
+                description: BoolOrString is a type that can hold a Boolean or a string.
+                oneOf:
+                - type: string
+                - type: boolean
+              type: object
+            host:
+              type: string
+            host_redirect:
+              type: boolean
+            host_regex:
+              type: boolean
+            host_rewrite:
+              type: string
+            idle_timeout_ms:
+              type: integer
+            keepalive:
+              properties:
+                idle_time:
+                  type: integer
+                interval:
+                  type: integer
+                probes:
+                  type: integer
+              type: object
+            labels:
+              additionalProperties:
+                description: A MappingLabelGroupsArray is an array of MappingLabelGroups. I know, complex.
+                items:
+                  additionalProperties:
+                    description: 'A MappingLabelsArray is the value in the MappingLabelGroup: an array of label specifiers.'
+                    items:
+                      description: A MappingLabelSpecifier (finally!) defines a single label. There are multiple kinds of label, so this is more complex than we'd like it to be. See the remarks about schema on custom types in `./common.go`.
+                    type: array
+                  description: 'A MappingLabelGroup is a single element of a MappingLabelGroupsArray: a second map, where the key is a human-readable name that identifies the group.'
+                  type: object
+                type: array
+              description: A DomainMap is the overall Mapping.spec.Labels type. It maps domains (kind of like namespaces for Mapping labels) to arrays of label groups.
+              type: object
+            load_balancer:
+              properties:
+                cookie:
+                  properties:
+                    name:
+                      type: string
+                    path:
+                      type: string
+                    ttl:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                header:
+                  type: string
+                policy:
+                  enum:
+                  - round_robin
+                  - ring_hash
+                  - maglev
+                  - least_request
+                  type: string
+                source_ip:
+                  type: boolean
+              required:
+              - policy
+              type: object
+            method:
+              type: string
+            method_regex:
+              type: boolean
+            modules:
+              items:
+                description: UntypedDict is relatively opaque as a Go type, but it preserves its contents in a roundtrippable way.
+                type: object
+              type: array
+            outlier_detection:
+              type: string
+            path_redirect:
+              description: Path replacement to use when generating an HTTP redirect. Used with `host_redirect`.
+              type: string
+            precedence:
+              type: integer
+            prefix:
+              type: string
+            prefix_exact:
+              type: boolean
+            prefix_redirect:
+              description: Prefix rewrite to use when generating an HTTP redirect. Used with `host_redirect`.
+              type: string
+            prefix_regex:
+              type: boolean
+            priority:
+              type: string
+            query_parameters:
+              additionalProperties:
+                description: BoolOrString is a type that can hold a Boolean or a string.
+                oneOf:
+                - type: string
+                - type: boolean
+              type: object
+            redirect_response_code:
+              description: The response code to use when generating an HTTP redirect. Defaults to 301. Used with `host_redirect`.
+              enum:
+              - 301
+              - 302
+              - 303
+              - 307
+              - 308
+              type: integer
+            regex_headers:
+              additionalProperties:
+                description: BoolOrString is a type that can hold a Boolean or a string.
+                oneOf:
+                - type: string
+                - type: boolean
+              type: object
+            regex_query_parameters:
+              additionalProperties:
+                description: BoolOrString is a type that can hold a Boolean or a string.
+                oneOf:
+                - type: string
+                - type: boolean
+              type: object
+            regex_redirect:
+              additionalProperties:
+                description: BoolOrString is a type that can hold a Boolean or a string.
+                oneOf:
+                - type: string
+                - type: boolean
+              description: Prefix regex rewrite to use when generating an HTTP redirect. Used with `host_redirect`.
+              type: object
+            regex_rewrite:
+              additionalProperties:
+                description: BoolOrString is a type that can hold a Boolean or a string.
+                oneOf:
+                - type: string
+                - type: boolean
+              type: object
+            remove_request_headers:
+              description: StringOrStringList is just what it says on the tin, but note that it will always marshal as a list of strings right now.
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            remove_response_headers:
+              description: StringOrStringList is just what it says on the tin, but note that it will always marshal as a list of strings right now.
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            resolver:
+              type: string
+            respect_dns_ttl:
+              type: boolean
+            retry_policy:
+              properties:
+                num_retries:
+                  type: integer
+                per_try_timeout:
+                  type: string
+                retry_on:
+                  enum:
+                  - 5xx
+                  - gateway-error
+                  - connect-failure
+                  - retriable-4xx
+                  - refused-stream
+                  - retriable-status-codes
+                  type: string
+              type: object
+            rewrite:
+              type: string
+            service:
+              type: string
+            shadow:
+              type: boolean
+            timeout_ms:
+              description: The timeout for requests that use this Mapping. Overrides `cluster_request_timeout_ms` set on the Ambassador Module, if it exists.
+              type: integer
+            tls:
+              description: BoolOrString is a type that can hold a Boolean or a string.
+              oneOf:
+              - type: string
+              - type: boolean
+            use_websocket:
+              description: 'use_websocket is deprecated, and is equivlaent to setting `allow_upgrade: ["websocket"]`'
+              type: boolean
+            weight:
+              type: integer
+          required:
+          - prefix
+          - service
+          type: object
+        status:
+          description: MappingStatus defines the observed state of Mapping
+          properties:
+            reason:
+              type: string
+            state:
+              enum:
+              - ""
+              - Inactive
+              - Running
+              type: string
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: modules.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: Module
+    listKind: ModuleList
+    plural: modules
+    singular: module
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: "A Module defines system-wide configuration.  The type of module is controlled by the .metadata.name; valid names are \"ambassador\" or \"tls\". \n https://www.getambassador.io/docs/edge-stack/latest/topics/running/ambassador/#the-ambassador-module https://www.getambassador.io/docs/edge-stack/latest/topics/running/tls/#tls-module-deprecated"
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            config:
+              description: UntypedDict is relatively opaque as a Go type, but it preserves its contents in a roundtrippable way.
+              type: object
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: ratelimitservices.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: RateLimitService
+    listKind: RateLimitServiceList
+    plural: ratelimitservices
+    singular: ratelimitservice
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: RateLimitService is the Schema for the ratelimitservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RateLimitServiceSpec defines the desired state of RateLimitService
+          properties:
+            ambassador_id:
+              description: Common to all Ambassador objects.
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            domain:
+              type: string
+            protocol_version:
+              enum:
+              - v2
+              - v3
+              type: string
+            service:
+              type: string
+            timeout_ms:
+              type: integer
+            tls:
+              description: BoolOrString is a type that can hold a Boolean or a string.
+              oneOf:
+              - type: string
+              - type: boolean
+          required:
+          - service
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: tcpmappings.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: TCPMapping
+    listKind: TCPMappingList
+    plural: tcpmappings
+    singular: tcpmapping
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: TCPMapping is the Schema for the tcpmappings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TCPMappingSpec defines the desired state of TCPMapping
+          properties:
+            address:
+              type: string
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            circuit_breakers:
+              items:
+                properties:
+                  max_connections:
+                    type: integer
+                  max_pending_requests:
+                    type: integer
+                  max_requests:
+                    type: integer
+                  max_retries:
+                    type: integer
+                  priority:
+                    enum:
+                    - default
+                    - high
+                    type: string
+                type: object
+              type: array
+            cluster_tag:
+              type: string
+            enable_ipv4:
+              type: boolean
+            enable_ipv6:
+              type: boolean
+            host:
+              type: string
+            idle_timeout_ms:
+              description: 'FIXME(lukeshu): Surely this should be an ''int''?'
+              type: string
+            port:
+              description: Port isn't a pointer because it's required.
+              type: integer
+            resolver:
+              type: string
+            service:
+              type: string
+            tls:
+              description: BoolOrString is a type that can hold a Boolean or a string.
+              oneOf:
+              - type: string
+              - type: boolean
+            weight:
+              type: integer
+          required:
+          - port
+          - service
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: tlscontexts.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: TLSContext
+    listKind: TLSContextList
+    plural: tlscontexts
+    singular: tlscontext
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: TLSContext is the Schema for the tlscontexts API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TLSContextSpec defines the desired state of TLSContext
+          properties:
+            alpn_protocols:
+              type: string
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            ca_secret:
+              type: string
+            cacert_chain_file:
+              type: string
+            cert_chain_file:
+              type: string
+            cert_required:
+              type: boolean
+            cipher_suites:
+              items:
+                type: string
+              type: array
+            ecdh_curves:
+              items:
+                type: string
+              type: array
+            hosts:
+              items:
+                type: string
+              type: array
+            max_tls_version:
+              enum:
+              - v1.0
+              - v1.1
+              - v1.2
+              - v1.3
+              type: string
+            min_tls_version:
+              enum:
+              - v1.0
+              - v1.1
+              - v1.2
+              - v1.3
+              type: string
+            private_key_file:
+              type: string
+            redirect_cleartext_from:
+              type: integer
+            secret:
+              type: string
+            secret_namespacing:
+              type: boolean
+            sni:
+              type: string
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  labels:
+    app.kubernetes.io/name: ambassador
+    product: aes
+  name: tracingservices.getambassador.io
+spec:
+  group: getambassador.io
+  names:
+    categories:
+    - ambassador-crds
+    kind: TracingService
+    listKind: TracingServiceList
+    plural: tracingservices
+    singular: tracingservice
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: TracingService is the Schema for the tracingservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TracingServiceSpec defines the desired state of TracingService
+          properties:
+            ambassador_id:
+              description: "AmbassadorID declares which Ambassador instances should pay attention to this resource.  May either be a string or a list of strings.  If no value is provided, the default is: \n    ambassador_id:    - \"default\""
+              items:
+                type: string
+              oneOf:
+              - type: string
+              - type: array
+            config:
+              properties:
+                access_token_file:
+                  type: string
+                collector_cluster:
+                  type: string
+                collector_endpoint:
+                  type: string
+                collector_endpoint_version:
+                  enum:
+                  - HTTP_JSON_V1
+                  - HTTP_JSON
+                  - HTTP_PROTO
+                  type: string
+                collector_hostname:
+                  type: string
+                service_name:
+                  type: string
+                shared_span_context:
+                  type: boolean
+                trace_id_128bit:
+                  type: boolean
+              type: object
+            driver:
+              enum:
+              - lightstep
+              - zipkin
+              - datadog
+              type: string
+            sampling:
+              properties:
+                client:
+                  type: integer
+                overall:
+                  type: integer
+                random:
+                  type: integer
+              type: object
+            service:
+              type: string
+            tag_headers:
+              items:
+                type: string
+              type: array
+          required:
+          - driver
+          - service
+          type: object
+      type: object
+  version: null
+  versions:
+  - name: v2
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false

--- a/cloud-native/ambassador/manifests/templates/mappings.yaml
+++ b/cloud-native/ambassador/manifests/templates/mappings.yaml
@@ -1,10 +1,13 @@
+{{- range $k, $v := .Values.user_agent_mappings }}
+---
 apiVersion: getambassador.io/v1
 kind:  Mapping
 metadata:
-  name:  black-hole-route-${SUFFIX}
+  name:  black-hole-route-{{- $k }}
   namespace: ingress
 spec:
   prefix: /
   service: https://hello.docai.beer
   headers:
-    user-agent: ${USER_AGENT}
+    user-agent: {{ $v }}
+{{- end }}

--- a/cloud-native/ambassador/manifests/values.yaml
+++ b/cloud-native/ambassador/manifests/values.yaml
@@ -1,0 +1,11 @@
+# Default values for manifests.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+user_agent_mappings:
+  a: "Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.0 Version/10.00"
+  b: "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.11) Gecko/2009060215 Firefox/3.0.11"
+  c: "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)"
+  d: "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)"
+  e: "Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/522.11.3 (KHTML, like Gecko) Version/3.0 Safari/522.11.3"
+  f: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0"

--- a/cloud-native/ambassador/manifests/values.yaml~
+++ b/cloud-native/ambassador/manifests/values.yaml~
@@ -1,0 +1,11 @@
+# Default values for manifests.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+user_agent_mappings:
+    a: "Opera/9.80 (Windows NT 6.0; U; en) Presto/2.2.0 Version/10.00"
+    b: "Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.11) Gecko/2009060215 Firefox/3.0.11"
+    c: "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)"
+    d: "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)"
+    e: "Mozilla/5.0 (Windows; U; Windows NT 5.1; en) AppleWebKit/522.11.3 (KHTML, like Gecko) Version/3.0 Safari/522.11.3"
+    f: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0"

--- a/cloud-native/ambassador/templates/values.yaml
+++ b/cloud-native/ambassador/templates/values.yaml
@@ -1,50 +1,11 @@
 ---
-# Default values for ambassador.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# Customized values for ambassador helm chart 6.6.0
 
-# Manually set metadata for the Release.
-#
-# Defaults to .Chart.Name
-nameOverride: ""
-# Defaults to .Release.Name-.Chart.Name unless .Release.Name contains "ambassador"
-fullnameOverride: ""
-# Defaults to .Release.Namespace
-namespaceOverride: ""
+# TODO: add
+#podDisruptionBudget: {}
 
-replicaCount: 3
-daemonSet: false
-
-# This will enable the test-ready Pod (https://github.com/datawire/ambassador-chart/blob/master/templates/tests/test-ready.yaml).
-# It will spawn a busybox container to call Ambassador's check_ready endpoint to validate it is working correctly.
-test:
-  enabled: true
-  image: busybox
-
-# Enable autoscaling using HorizontalPodAutoscaler
-# daemonSet: true, autoscaling will be disabled
-autoscaling:
-  enabled: false
-  minReplicas: 2
-  maxReplicas: 5
-  metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 60
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 60
-
-podDisruptionBudget: {}
-
-# namespace:
-  # name: default
+namespace:
+  name: ingress
 
 # Additional container environment variable
 # Uncomment or add additional environment variables for the container here.
@@ -52,123 +13,22 @@ env:
   # Exposing statistics via StatsD
   STATSD_ENABLED: true
   STATSD_HOST: localhost
-  # sets the minimum number of seconds between Envoy restarts
-  # AMBASSADOR_RESTART_TIME: 15
-  # sets the number of seconds that the Envoy will wait for open connections to drain on a restart
-  # AMBASSADOR_DRAIN_TIME: 5
-  # sets the number of seconds that Ambassador will wait for the old Envoy to clean up and exit on a restart
-  # AMBASSADOR_SHUTDOWN_TIME: 10
-  # labels Ambassador with an ID to allow for configuring multiple Ambassadors in a cluster
-  # AMBASSADOR_ID: default
-
-# Additional container environment variable in raw YAML format
-# Uncomment or add additional environment variables for the container here.
-envRaw: {}
-# - name: REDIS_PASSWORD
-#   value: password
-#   valueFrom:
-#     secretKeyRef:
-#       name: redis-password
-#       key: password
-# - name: POD_IP
-#   valueFrom:
-#     fieldRef:
-#       fieldPath: status.podIP
-
-imagePullSecrets: []
-
-security:
-  # Security Context for all containers in the pod.
-  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core
-  podSecurityContext:
-    runAsUser: 8888
-  # Security Context for the Ambassador container specifically
-  # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core
-  containerSecurityContext:
-    allowPrivilegeEscalation: false
-  # A basic PodSecurityPolicy to ensure Ambassador is running with appropriate security permissions
-  # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
-  #
-  # A set of reasonable defaults is outlined below. This is not created by default as it should only
-  # be created by a one Release. If you want to use the PodSecurityPolicy in the chart, create it in
-  # the "master" Release and then leave it unset in all others. Set the `rbac.podSecurityPolicies`
-  # in all non-"master" Releases.
-  podSecurityPolicy:
-    # # Add AppArmor and Seccomp annotations
-    # # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
-    # annotations:
-    # spec:
-    #   seLinux:
-    #     rule: RunAsAny
-    #   supplementalGroups:
-    #     rule: 'MustRunAs'
-    #     ranges:
-    #       # Forbid adding the root group.
-    #       - min: 1
-    #         max: 65535
-    #   fsGroup:
-    #     rule: 'MustRunAs'
-    #     ranges:
-    #       # Forbid adding the root group.
-    #       - min: 1
-    #         max: 65535
-    #   privileged: false
-      # allowPrivilegeEscalation: false
-      # runAsUser:
-      #   rule: MustRunAsNonRoot
 
 image:
   repository: docker.io/datawire/aes
-  tag: 1.12.1
+  tag: 1.14.2
   pullPolicy: IfNotPresent
-
-dnsPolicy: "ClusterFirst"
-hostNetwork: false
 
 service:
   type: LoadBalancer
 
-
   # Note that target http ports need to match your ambassador configurations service_port
   # https://www.getambassador.io/reference/modules/#the-ambassador-module
   ports:
-    # - name: http
-    #   port: 80
-    #   targetPort: 8080
-      # protocol: TCP
-      # nodePort: 30080
-      # hostPort: 80
+    - name: http
+      port: 80
     - name: https
       port: 443
-      targetPort: 8443
-      # protocol: TCP
-      # nodePort: 30443
-      # hostPort: 443
-    # TCPMapping_Port
-      # port: 2222
-      # targetPort: 2222
-      # protocol: TCP
-      # nodePort: 30222
-
-  externalTrafficPolicy:
-
-  sessionAffinity:
-
-  sessionAffinityConfig:
-
-  externalIPs: []
-
-  # Manually set the name of the generated Service
-  nameOverride:
-  #############################################################################
-  ## Ambassador should be configured using CRD definition. If you want
-  ## to use annotations, the following is an example of annotating the
-  ## Ambassador service with global configuration manifest.
-  ##
-  ## See https://www.getambassador.io/reference/core/ambassador and
-  ## https://www.getambassador.io/reference/core/tls for more info
-  #############################################################################
-  #
   annotations:
     getambassador.io/config: |
       ---
@@ -211,101 +71,9 @@ adminService:
   type: ClusterIP
   port: 8877
   snapshotPort: 8005
-  # NodePort used if type is NodePort
-  # nodePort: 38877
-
-rbac:
-  # Specifies whether RBAC resources should be created
-  create: true
-  # List of Pod Security Policies to use on the container.
-  # If security.podSecurityPolicy is set, it will be appended to the list
-  podSecurityPolicies: []
-  # Name of the RBAC resources defaults to the name of the release.
-  # Set nameOverride when installing Ambassador with cluster-wide scope in
-  # different namespaces with the same release name to avoid conflicts.
-  nameOverride:
-
-scope:
-  # tells Ambassador to only use resources in the namespace or namespace set by namespace.name
-  singleNamespace: false
-
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name:
-
-deploymentStrategy:
-  type: RollingUpdate
-
-restartPolicy:
-
-terminationGracePeriodSeconds:
-
-initContainers: []
-
-sidecarContainers: []
-
-livenessProbe:
-  initialDelaySeconds: 30
-  periodSeconds: 3
-  failureThreshold: 3
-
-readinessProbe:
-  initialDelaySeconds: 30
-  periodSeconds: 3
-  failureThreshold: 3
-
-
-volumes: []
-
-volumeMounts: []
 
 podLabels:
   service: statsd-sink
-
-podAnnotations: {}
-
-deploymentLabels:
-  {}
-
-deploymentAnnotations:
-  {}
-  # configmap.reloader.stakater.com/auto: "true"
-
-resources: {}
-  # Recommended resource requests and limits for Ambassador
-  # limits:
-  #   cpu: 1000m
-  #   memory: 600Mi
-  # requests:
-  #   cpu: 200m
-  #   memory: 300Mi
-
-priorityClassName: ""
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-ambassadorConfig: ""
-
-crds:
-  enabled: true
-  create: true
-  keep: true
-
-# Prometheus Operator ServiceMonitor configuration
-# See documentation: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor
-metrics:
-  serviceMonitor:
-    enabled: true
-    interval: 30s
-    scrapeTimeout: 30s
-    # selector: {}
 
 ################################################################################
 ## Ambassador Edge Stack Configuration                                        ##
@@ -317,182 +85,6 @@ metrics:
 
 enableAES: false
 
-# Set createSecret: false is installing multiple releases of The Ambassador
-# Edge Stack in the same namespace.
-licenseKey:
-  value:
-  createSecret: true
-  secretName:
-  # Annotations to attach to the license-key-secret.
-  annotations:
-    {}
-
-# The DevPortal is exposed at /docs/ endpoint in the AES container.
-# Setting this to true will automatically create routes for the DevPortal.
-createDevPortalMappings: false
-
-# The Ambassador Edge Stack uses a redis instance for managing authentication,
-# rate limiting, and sharing minor configuration details between pods for
-# centralized management. These values configure the redis instance that ships
-# by default with The Ambassador Edge Stack.
-#
-# URL of your redis instance. Defaults to redis instance created below.
-redisURL:
-
 # Ambassador ships with a basic redis instance. Configure the deployment with the options below.
 redis:
-  create: true
-  image:
-    repository: redis
-    tag: 5.0.1
-    pullPolicy: IfNotPresent
-  # Annotations for Ambassador Pro's redis instance.
-  annotations:
-    deployment:
-      {}
-    service:
-      {}
-  resources: {}
-  # If you want to specify resources, uncomment the following
-  # lines and remove the curly braces after 'resources:'.
-  # These are placeholder values and must be tuned.
-  #   limits:
-  #     cpu: 100m
-  #     memory: 256Mi
-  #   requests:
-  #     cpu: 50m
-  #     memory: 128Mi
-  nodeSelector: {}
-  affinity: {}
-  tolerations: {}
-
-
-# Configures the AuthService that ships with the Ambassador Edge Stack.
-# Setting authService.create: false will not install the AES AuthService and
-# allow you to define your own.
-#
-# Typically when using the AES, you will want to keep this set to true and use
-# the External Filter to communicate with a custom authentication service.
-# https://www.getambassador.io/reference/filter-reference/#filter-type-external
-authService:
   create: false
-  # Set additional configuration options. See https://www.getambassador.io/reference/services/auth-service for more information
-  optional_configurations:
-    # include_body:
-    #   max_bytes: 4096
-    #   allow_partial: true
-    # status_on_error:
-    #   code: 403
-    # failure_mode_allow: false
-    # retry_policy:
-    #   retry_on: "5xx"
-    #   num_retries: 2
-    # add_linkerd_headers: true
-    # timeout_ms: 30000
-
-
-# Configures the RateLimitService in the Ambassador Edge Stack.
-# Keep this enabled to configure RateLimits in AES.
-rateLimit:
-  create: false
-
-# Projects are a beta feature of Ambassador that allow developers to stage and
-# deploy code with nothing more than a Github repository.
-# See: https://www.getambassador.io/docs/latest/topics/using/projects/
-registry:
-  create: false
-
-# Resolvers are used to configure the discovery service strategy for Ambasador Edge Stack.
-# See: https://www.getambassador.io/docs/latest/topics/running/resolvers/
-resolvers:
-  endpoint:
-    create: false
-    name: "endpoint"
-  consul:
-    create: false
-    name: "consul-dc1"
-    spec: {}
-    # Configuration for a Consul Resolver
-    #   address: consul-server.default.svc.cluster.local:8500
-    #   datacenter: dc1
-
-################################################################################
-## DEPRECATED configuration objects                                           ##
-################################################################################
-
-# DEPRECATED: Ambassador now exposes the /metrics endpoint in Envoy.
-# DEPRECATED: See https://www.getambassador.io/user-guide/monitoring#deployment for more information on how to use the /metrics endpoint
-#
-# DEPRECATED: Enabling the prometheus exporter creates a sidecar and configures ambassador to use it
-prometheusExporter:
-  enabled: false
-  repository: prom/statsd-exporter
-  tag: v0.8.1
-  pullPolicy: IfNotPresent
-  resources: {}
-  # If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  #   limits:
-  #     cpu: 100m
-  #     memory: 256Mi
-  #   requests:
-  #     cpu: 50m
-  #     memory: 128Mi
-  # You can configure the statsd exporter to modify the behavior of mappings and other features.
-  # See documentation: https://github.com/prometheus/statsd_exporter/tree/v0.8.1#metric-mapping-and-configuration
-  # Uncomment the following line if you wish to specify a custom configuration:
-  # configuration: |
-  #   ---
-  #   mappings:
-  #   - match: 'envoy.cluster.*.upstream_cx_connect_ms'
-  #     name: "envoy_cluster_upstream_cx_connect_time"
-  #     timer_type: 'histogram'
-  #     labels:
-  #       cluster_name: "$1"
-
-# DEPRECATED: Use security.podSecurityContext
-# securityContext:
-#   runAsUser: 8888
-
-
-# Configures Service Preview that ships with the Ambassador Edge Stack and edgectl.
-# Setting servicePreview.enabled: true will install the Traffic Agent Service Account, Traffic Manager with RBAC, and ambassador-injector
-servicePreview:
-  enabled: false
-  trafficManager:
-    image:
-      # Leave blank to use image.repository and image.tag
-      repository:
-      tag:
-    serviceAccountName: "traffic-manager"
-  trafficAgent:
-    image:
-      # Leave blank to use image.repository and image.tag
-      repository:
-      tag:
-    singleNamespace: true
-    serviceAccountName: "traffic-agent"
-    port: 9900
-
-    # Configure the ambassador-injector webhook for Service Preview Traffic Agent automatic sidecar injection.
-    injector:
-      enabled: true
-
-      # If no injector.crtPEM and injector.keyPEM are provided, a self-signed certificate will be issued
-      # for the Common Name (CN) of `<ambassador-injector>.<namespace>.svc`, which is the cluster-internal DNS name
-      # for the service.
-      crtPEM: ""
-      keyPEM: ""
-
-# Configure the ambassador agent
-agent:
-  enabled: false
-  # this will be empty when it first gets applied, then the user will edit the agent to
-  # make it start reporting
-  cloudConnectToken: ""
-  rpcAddress: https://app.getambassador.io/
-  image:
-    # Leave blank to use image.repository and image.tag
-    tag:
-    repository:
-deploymentTool: ""

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -1,6 +1,6 @@
 module "gke" {
   source                     = "terraform-google-modules/kubernetes-engine/google"
-  version                    = "14.3.0"
+  version                    = "17.3.0"
   project_id                 = var.project_id
   name                       = "${var.project_id}-cluster"
   region                     = var.region


### PR DESCRIPTION
Ambassador/Emissary no longer applies CRDs with Helm apparently, so I downloaded the 6.6.0 version of the CRDs and included it with the User-Agent Mapping manifests.  This may change with Emissary 2.x and 6.9.x helm chart, but works for now.