### PR TITLE
Fix Prometheus metric path for jupyter notebook

### DIFF
--- a/cloud-native/prometheus-toniq/templates/prometheus.values.yaml
+++ b/cloud-native/prometheus-toniq/templates/prometheus.values.yaml
@@ -2869,7 +2869,6 @@ prometheus:
         source_labels:
         - __meta_kubernetes_pod_annotation_prometheus_io_path
         target_label: __metrics_path__
-        replacement: /notebook$1
       - action: replace
         regex: ([^:]+)(?::\d+)?;(\d+)
         replacement: $1:$2


### PR DESCRIPTION
- The io/path is set by toniq-operator with correct prefix. No need to hardcode the prefix.